### PR TITLE
fix: allow routing key to be empty string and null

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
     - name: Clone the repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Buildah Action
       id: build-image

--- a/cli.js
+++ b/cli.js
@@ -25,6 +25,9 @@ const logFailures = (failures) => {
 			return failure.message;
 		}).join('\n'),
 	);
+	if (failures.length) {
+		console.error('Total nr of failures:', failures.length);
+	}
 };
 
 console.debug(`Validating a definitions file at ${fullFilePath}${fullUsageFilePath ? ' with usage stats from ' + fullUsageFilePath : ''}`);

--- a/fixtures/full.json
+++ b/fixtures/full.json
@@ -17,6 +17,9 @@
   "vhosts": [
     {
       "name": "/"
+    },
+    {
+      "name": "isolated"
     }
   ],
   "permissions": [

--- a/fixtures/full.json
+++ b/fixtures/full.json
@@ -58,9 +58,9 @@
   ],
   "exchanges": [
     {
-      "name": "anotherex2",
+      "name": "defect_direct",
       "vhost": "/",
-      "type": "topic",
+      "type": "direct",
       "durable": true,
       "auto_delete": false,
       "internal": false,
@@ -96,6 +96,16 @@
   ],
   "bindings": [
     {
+      "source": "defect_headers",
+      "vhost": "/",
+      "destination": "defect_queue",
+      "destination_type": "queue",
+      "routing_key": "",
+      "arguments": {
+        "x-match": "any"
+      }
+    },
+    {
       "source": "isolated_defect_headers",
       "vhost": "isolated",
       "destination": "defect_queue",
@@ -114,16 +124,6 @@
       "arguments": {
         "x-match": "any",
         "header1": "value1"
-      }
-    },
-    {
-      "source": "defect_headers",
-      "vhost": "/",
-      "destination": "defect_queue",
-      "destination_type": "queue",
-      "routing_key": "",
-      "arguments": {
-        "x-match": "any"
       }
     }
   ]

--- a/fixtures/usage.full.json
+++ b/fixtures/usage.full.json
@@ -1,5 +1,5 @@
 [
-	{ "vhost": "/", "queue": "defect_queue", "exchange": "anotherex2" },
+	{ "vhost": "/", "queue": "defect_queue", "exchange": "defect_direct" },
 	{ "vhost": "/", "queue": "defect_queue", "exchange": "defect_topic" },
 	{ "vhost": "/", "queue": "defect_queue", "exchange": "defect_headers" },
 	{ "vhost": "isolated", "queue": "defect_queue", "exchange": "isolated_defect_headers" }

--- a/src/Index.js
+++ b/src/Index.js
@@ -130,7 +130,7 @@ class Index {
 				let args = undefined;
 				if (from.type === 'headers') {
 					// TODO: TEST THIS
-					assert.equal(binding.routing_key, '', `Routing key is ignored for header exchanges, but set for binding from ${binding.source} to ${binding.destination_type} "${binding.destination}" in vhost "${vhost}"`);
+					assert.ok(!binding.routing_key, `Routing key is ignored for header exchanges, but set("${binding.routing_key}") for binding from ${binding.source} to ${binding.destination_type} "${binding.destination}" in vhost "${vhost}"`);
 					args = binding.arguments;
 				} else if (from.type === 'topic') {
 					// TODO: TEST THIS

--- a/src/relations.js
+++ b/src/relations.js
@@ -21,7 +21,7 @@ const assertRelations = (definitions, throwOnFirstError = true) => {
 	for (const vhost of definitions.vhosts) {
 		if (!index.db.resourceByVhost.get(vhost.name)) {
 			if (vhost.name) {
-				console.warn(`Unused vhost: "${vhost.name}"`);
+				console.warn(`Warning: Unused vhost: "${vhost.name}"`);
 			}
 		}
 	}
@@ -30,7 +30,7 @@ const assertRelations = (definitions, throwOnFirstError = true) => {
 	for (const queue of definitions.queues) {
 		if (!index.db.bindingByDestination.get(queue)) {
 			if (queue.name && queue.vhost) {
-				console.warn(`Unbound queue: "${queue.name}" in vhost "${queue.vhost}"`);
+				console.warn(`Warning: Unbound queue: "${queue.name}" in vhost "${queue.vhost}"`);
 			}
 		}
 	}
@@ -39,7 +39,7 @@ const assertRelations = (definitions, throwOnFirstError = true) => {
 	for (const exchange of definitions.exchanges) {
 		if (!index.db.binding.get(exchange) && !index.db.bindingByDestination.get(exchange)) {
 			if (exchange.name && exchange.vhost) {
-				console.warn(`Unbound exchange: "${exchange.name}" in vhost "${exchange.vhost}"`);
+				console.warn(`Warning: Unbound exchange: "${exchange.name}" in vhost "${exchange.vhost}"`);
 			}
 		}
 	}

--- a/src/structure.js
+++ b/src/structure.js
@@ -4,6 +4,7 @@ import {
 	assert as assertStructure,
 	boolean,
 	enums,
+	nullable,
 	number,
 	object,
 	optional,
@@ -111,7 +112,7 @@ const rootStructure = {
 		vhost: string(),
 		destination: string(),
 		destination_type: string(),
-		routing_key: string(),
+		routing_key: nullable(string()),
 		arguments: optional(object()),
 	})),
 };

--- a/src/usage.js
+++ b/src/usage.js
@@ -15,7 +15,7 @@ const assertUsage = (definitions, usageStats, throwOnFirstError = false) => {
 	const assert = failureCollector(throwOnFirstError);
 	const index = new Index();
 	// collect failures but ignore issues for compiling usage failures
-	index.build(definitions, true);
+	index.build(definitions, false);
 
 	// Check resources that are used, but missing from definitions
 	// Likely to be temporary resources.

--- a/test/relations.js
+++ b/test/relations.js
@@ -19,6 +19,17 @@ describe('asserting relations', () => {
 		});
 	});
 
+	describe('missing', () => {
+		it('vhost', () => {
+			const def = copy(valid);
+			def.vhosts.pop();
+
+			assert.throws(() => {
+				assertRelations(def);
+			}, /missing.*vhost/i);
+		});
+	});
+
 	describe('duplicates', () => {
 		it('vhosts', () => {
 			const def = copy(valid);
@@ -31,9 +42,10 @@ describe('asserting relations', () => {
 
 		it('queues', () => {
 			const def = copy(valid);
-			const newQueue = copy(def.queues[0]);
-			newQueue.vhost = 'empty_vhost';
-			def.queues.push(newQueue);
+			def.vhosts.push({ name: 'empty_vhost' });
+			const newResource = copy(def.queues[0]);
+			newResource.vhost = 'empty_vhost';
+			def.queues.push(newResource);
 
 			// should pass because of the different vhost
 			assertRelations(def);
@@ -47,9 +59,10 @@ describe('asserting relations', () => {
 
 		it('exchanges', () => {
 			const def = copy(valid);
-			const newQueue = copy(def.exchanges[0]);
-			newQueue.vhost = 'empty_vhost';
-			def.exchanges.push(newQueue);
+			def.vhosts.push({ name: 'empty_vhost' });
+			const newResource = copy(def.exchanges[0]);
+			newResource.vhost = 'empty_vhost';
+			def.exchanges.push(newResource);
 
 			// should pass because of the different vhost
 			assertRelations(def);

--- a/test/relations.js
+++ b/test/relations.js
@@ -30,6 +30,40 @@ describe('asserting relations', () => {
 		});
 	});
 
+	describe('excessive configuration on bindings', () => {
+		it('from header exchange', () => {
+			const def = copy(valid);
+			def.bindings[0].routing_key = '#';
+			def.bindings[0].arguments['x-match'] = 'all';
+
+			assert.throws(() => {
+				assertRelations(def);
+			}, /Routing key is ignored for header exchanges/i);
+		});
+
+		it('from topic exchange', () => {
+			const def = copy(valid);
+			def.bindings[0].routing_key = '#';
+			def.bindings[0].arguments['x-match'] = 'all';
+			def.bindings[0].source = 'defect_topic';
+
+			assert.throws(() => {
+				assertRelations(def);
+			}, /Match arguments are ignored for topic exchanges,/i);
+		});
+
+		it('from direct exchange', () => {
+			const def = copy(valid);
+			def.bindings[0].routing_key = '#';
+			def.bindings[0].arguments['x-match'] = 'all';
+			def.bindings[0].source = 'defect_direct';
+
+			assert.throws(() => {
+				assertRelations(def);
+			}, /Match arguments are ignored for direct exchanges,/i);
+		});
+	});
+
 	describe('duplicates', () => {
 		it('vhosts', () => {
 			const def = copy(valid);

--- a/test/test-cli.sh
+++ b/test/test-cli.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env sh
 
-node cli.js fixtures/empty.json || exit 1
-node cli.js fixtures/empty.json fixtures/usage.empty.json || exit 1
+assert_succeeds () {
+	(node cli.js $@) || exit 1
+	echo
+}
 
-node cli.js fixtures/full.json || exit 1
-node cli.js fixtures/full.json fixtures/usage.full.json || exit 1
+assert_fails () {
+	! (node cli.js $@) && echo "Expected failure: OK" || exit 1
+	echo
+}
 
-! node cli.js fixtures/full.json fixtures/usage.empty.json && echo "Expected failure: OK" || exit 1
+assert_succeeds fixtures/empty.json
+assert_succeeds fixtures/empty.json fixtures/usage.empty.json
+assert_succeeds fixtures/full.json
+assert_succeeds fixtures/full.json fixtures/usage.full.json
 
-! node cli.js fixtures/full-invalid.json && echo "Expected failure: OK" || exit 1
-! node cli.js fixtures/full-invalid-relations.json && echo "Expected failure: OK" || exit 1
+assert_fails fixtures/full.json fixtures/usage.empty.json
+assert_fails fixtures/full-invalid.json
+assert_fails fixtures/full-invalid-relations.json

--- a/test/usage.js
+++ b/test/usage.js
@@ -10,7 +10,7 @@ const copy = (obj) => {
 
 const valid = readJSONSync('./fixtures/full.json');
 const usage = [
-	{ vhost: '/', queue: 'defect_queue', exchange: 'anotherex2' },
+	{ vhost: '/', queue: 'defect_queue', exchange: 'defect_direct' },
 	{ vhost: '/', queue: 'defect_queue', exchange: 'defect_topic' },
 	{ vhost: '/', queue: 'defect_queue', exchange: 'defect_headers' },
 	{ vhost: 'isolated', queue: 'defect_queue', exchange: 'isolated_defect_headers' },


### PR DESCRIPTION
- feat: update actions/checkout
- fix: add vhost to full.json fixture
- feat: test if used vhosts are defined
- fix: don't throw when building index for assertUsage
- fix: allow empty strings as routing keys for bindings from header ex
- feat: report total number of failures
- test: test excessive parameters on bindings
- fix: state unbound resources as warnings
- feat: allow routing key to be null
