### PR TITLE
feat: turn empirically unused resource cases into warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rabbit-validator",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "Validator for the definition files of RabbitMQ",
   "main": "src/validate.js",

--- a/src/relations.js
+++ b/src/relations.js
@@ -21,7 +21,7 @@ const assertRelations = (definitions, throwOnFirstError = true) => {
 	for (const vhost of definitions.vhosts) {
 		if (!index.db.resourceByVhost.get(vhost.name)) {
 			if (vhost.name) {
-				console.warn(`Warning: Unused vhost: "${vhost.name}"`);
+				console.warn(`Warning: Unused vhost "${vhost.name}"`);
 			}
 		}
 	}
@@ -30,7 +30,7 @@ const assertRelations = (definitions, throwOnFirstError = true) => {
 	for (const queue of definitions.queues) {
 		if (!index.db.bindingByDestination.get(queue)) {
 			if (queue.name && queue.vhost) {
-				console.warn(`Warning: Unbound queue: "${queue.name}" in vhost "${queue.vhost}"`);
+				console.warn(`Warning: Unbound queue "${queue.name}" in vhost "${queue.vhost}"`);
 			}
 		}
 	}
@@ -39,7 +39,7 @@ const assertRelations = (definitions, throwOnFirstError = true) => {
 	for (const exchange of definitions.exchanges) {
 		if (!index.db.binding.get(exchange) && !index.db.bindingByDestination.get(exchange)) {
 			if (exchange.name && exchange.vhost) {
-				console.warn(`Warning: Unbound exchange: "${exchange.name}" in vhost "${exchange.vhost}"`);
+				console.warn(`Warning: Unbound exchange "${exchange.name}" in vhost "${exchange.vhost}"`);
 			}
 		}
 	}

--- a/src/usage.js
+++ b/src/usage.js
@@ -57,7 +57,7 @@ const assertUsage = (definitions, usageStats, throwOnFirstError = false) => {
 	const vhostUnused = [...index.db.vhost.values()];
 	if (vhostSizeBefore > 1 && vhostUnused.length) {
 		for (const i of vhostUnused) {
-			assert.fail(`Empirically unused vhost: ${i.name}`);
+			console.warn(`Warning: Empirically unused vhost "${i.name}"`);
 		}
 		const vhostRatio = vhostUnused.length / vhostSizeBefore;
 		assert.ok(vhostRatio < 0.3, `High ratio of unused vhost resources: ${formatPercentage(vhostRatio)}`);
@@ -66,7 +66,7 @@ const assertUsage = (definitions, usageStats, throwOnFirstError = false) => {
 	const exchangeUnused = [...index.db.exchange.values()];
 	if (exchangeSizeBefore && exchangeUnused.length) {
 		for (const i of exchangeUnused) {
-			assert.fail(`Empirically unused exchange: "${i.name}" in "${i.vhost}"`);
+			console.warn(`Warning: Empirically unused exchange "${i.name}" in "${i.vhost}"`);
 		}
 		const exchangeRatio = exchangeUnused.length / exchangeSizeBefore;
 		assert.ok(exchangeRatio < 0.3, `High ratio of unused exchange resources: ${formatPercentage(exchangeRatio)}`);
@@ -75,7 +75,7 @@ const assertUsage = (definitions, usageStats, throwOnFirstError = false) => {
 	const queueUnused = [...index.db.queue.values()];
 	if (queueSizeBefore && queueUnused.length) {
 		for (const i of queueUnused) {
-			assert.fail(`Empirically unused queue: "${i.name}" in "${i.vhost}"`);
+			console.warn(`Warning: Empirically unused queue "${i.name}" in "${i.vhost}"`);
 		}
 		const queueRatio = queueUnused.length / queueSizeBefore;
 		assert.ok(queueRatio < 0.3, `High ratio of unused queue resources: ${formatPercentage(queueRatio)}`);

--- a/src/usage.js
+++ b/src/usage.js
@@ -60,7 +60,7 @@ const assertUsage = (definitions, usageStats, throwOnFirstError = false) => {
 			console.warn(`Warning: Empirically unused vhost "${i.name}"`);
 		}
 		const vhostRatio = vhostUnused.length / vhostSizeBefore;
-		assert.ok(vhostRatio < 0.3, `High ratio of unused vhost resources: ${formatPercentage(vhostRatio)}`);
+		assert.ok(vhostRatio < 0.3, `High ratio of unused vhosts: ${formatPercentage(vhostRatio)}`);
 	}
 
 	const exchangeUnused = [...index.db.exchange.values()];
@@ -69,7 +69,7 @@ const assertUsage = (definitions, usageStats, throwOnFirstError = false) => {
 			console.warn(`Warning: Empirically unused exchange "${i.name}" in "${i.vhost}"`);
 		}
 		const exchangeRatio = exchangeUnused.length / exchangeSizeBefore;
-		assert.ok(exchangeRatio < 0.3, `High ratio of unused exchange resources: ${formatPercentage(exchangeRatio)}`);
+		assert.ok(exchangeRatio < 0.3, `High ratio of unused exchanges: ${formatPercentage(exchangeRatio)}`);
 	}
 
 	const queueUnused = [...index.db.queue.values()];
@@ -78,7 +78,7 @@ const assertUsage = (definitions, usageStats, throwOnFirstError = false) => {
 			console.warn(`Warning: Empirically unused queue "${i.name}" in "${i.vhost}"`);
 		}
 		const queueRatio = queueUnused.length / queueSizeBefore;
-		assert.ok(queueRatio < 0.3, `High ratio of unused queue resources: ${formatPercentage(queueRatio)}`);
+		assert.ok(queueRatio < 0.3, `High ratio of unused queues: ${formatPercentage(queueRatio)}`);
 	}
 
 	return assert.collectFailures();

--- a/test/usage.js
+++ b/test/usage.js
@@ -38,10 +38,16 @@ describe('asserting usage', () => {
 			def.vhosts.push({
 				name: 'unused_vhost',
 			});
+			def.vhosts.push({
+				name: 'unused_vhost2',
+			});
+			def.vhosts.push({
+				name: 'unused_vhost3',
+			});
 
 			assert.throws(() => {
 				assertUsage(def, usage, opts);
-			}, /unused_vhost/);
+			}, /High ratio of unused vhost/);
 		});
 
 		it('queues', () => {
@@ -53,7 +59,7 @@ describe('asserting usage', () => {
 
 			assert.throws(() => {
 				assertUsage(def, usage, opts);
-			}, /unused_queue/);
+			}, /High ratio of unused queue/);
 		});
 
 		it('exchanges', () => {
@@ -62,10 +68,18 @@ describe('asserting usage', () => {
 				vhost: '/',
 				name: 'unused_exchange',
 			});
+			def.exchanges.push({
+				vhost: '/',
+				name: 'unused_exchange2',
+			});
+			def.exchanges.push({
+				vhost: '/',
+				name: 'unused_exchange3',
+			});
 
 			assert.throws(() => {
 				assertUsage(def, usage, opts);
-			}, /unused_exchange/);
+			}, /High ratio of unused exchange/);
 		});
 	});
 });


### PR DESCRIPTION
- feat: avoid using multiple colons in warnings
- feat: warn instead of failing on empirically unused resources
