### PR TITLE
feat: implement definition diffing

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,42 +1,86 @@
 #!/usr/bin/env node
 
+import { strict as assert } from 'node:assert';
 import path from 'node:path';
-import { strict as assert } from 'assert';
+import { inspect } from 'node:util';
+
 import validate from './src/validate.js';
+import diff from './src/diff.js';
+import { readJSONSync } from './src/utils.js';
 
-const [,, filePath, usageFilePath] = process.argv;
+const [,, subcommand, ...args] = process.argv;
 
-if (!filePath) {
-	console.error('usage: rabbit-validator <path/definitions.json> [<path/usage.json>]');
-	console.error('       usage.json is a fail containing array of objects { vhost, exchange, queue } | { vhost, queue } of used RabbitMQ resources.');
+if (!subcommand) {
+	console.error('usage: rabbit-validator <COMMAND> <OPTIONS>');
+	console.error('Commands:');
+	console.error('\tvalidate <path/definitions.json> [<path/usage.json>] # Validates definition file');
+	console.error('\t         usage.json is a fail containing array of objects { vhost, exchange, queue } | { vhost, queue } of used RabbitMQ resources.');
+	console.error('\tdiff <path/definitions.before.json> <path/definitions.after.json> # Diffs two definition files');
 	process.exit(1);
 }
 
-const fullFilePath = path.resolve(filePath);
-const fullUsageFilePath = usageFilePath && path.resolve(usageFilePath);
+const commands = {
+	validate: (filePath, usageFilePath) => {
+		const fullFilePath = path.resolve(filePath);
+		const fullUsageFilePath = usageFilePath && path.resolve(usageFilePath);
 
-const logFailures = (failures) => {
-	assert.equal(Array.isArray(failures), true, `Invalid list of failures: ${failures}`);
-	console.error(
-		failures.map((failure) => {
-			if (failure.path) {
-				return `At ${failure.path.join('.')}: ${failure.message}`;
+		const logFailures = (failures) => {
+			assert.equal(Array.isArray(failures), true, `Invalid list of failures: ${failures}`);
+			console.error(
+				failures.map((failure) => {
+					if (failure.path) {
+						return `At ${failure.path.join('.')}: ${failure.message}`;
+					}
+					return failure.message;
+				}).join('\n'),
+			);
+			if (failures.length) {
+				console.error('Total nr of failures:', failures.length);
 			}
-			return failure.message;
-		}).join('\n'),
-	);
-	if (failures.length) {
-		console.error('Total nr of failures:', failures.length);
-	}
+		};
+
+		console.debug(`Validating a definitions file at ${fullFilePath}${fullUsageFilePath ? ' with usage stats from ' + fullUsageFilePath : ''}`);
+
+		// Failure[]
+		const failures = validate(fullFilePath, fullUsageFilePath);
+		if (failures.length) {
+			logFailures(failures);
+			process.exit(1);
+		} else {
+			console.log('OK');
+		}
+	},
+	diff: (beforeInput, afterInput) => {
+		assert.equal(typeof beforeInput, 'string', 'Path to before definitions required');
+		assert.equal(typeof afterInput, 'string', 'Path to after definitions required');
+
+		const before = path.resolve(beforeInput);
+		const after = path.resolve(afterInput);
+
+		const result = diff(readJSONSync(before), readJSONSync(after));
+		inspect.defaultOptions.depth += 2;
+		console.log(
+			Object.fromEntries(
+				Object.entries(result)
+					.reduce((acc, [op, resources]) => {
+						const shaken = Object.entries(resources)
+							.filter(([, changes]) => changes.length);
+						if (shaken.length) {
+							acc.push([op, Object.fromEntries(shaken)]);
+						}
+						return acc;
+					}, [])
+			)
+		);
+	},
 };
 
-console.debug(`Validating a definitions file at ${fullFilePath}${fullUsageFilePath ? ' with usage stats from ' + fullUsageFilePath : ''}`);
-
-// Failure[]
-const failures = validate(fullFilePath, fullUsageFilePath);
-if (failures.length) {
-	logFailures(failures);
-	process.exit(1);
+if (subcommand === 'diff') {
+	// rabbit-validator diff <path/definitions.before.json> <path/definitions.after.json>
+	commands.diff(args[0], args[1]);
+} else if (subcommand === 'validate') {
+	commands.validate(args[0], args[1]);
 } else {
-	console.log('OK');
+	console.error('Running rabbit-validator without subcommand is deprecated');
+	commands.validate(subcommand, args[0]);
 }

--- a/src/Failure.js
+++ b/src/Failure.js
@@ -6,6 +6,7 @@ export default class Failure {
 	explanation = null;
 	value = null;
 	key = null;
+	stack = null;
 
 	static arrayFromSuperstructError(error) {
 		if (error === undefined) {
@@ -20,11 +21,12 @@ export default class Failure {
 		return new Failure({ message, value, key, path, explanation });
 	}
 
-	constructor({ message, value, key, path, explanation }) {
+	constructor({ message, value, key, path, explanation, stack }) {
 		this.message = message;
-		this.value = value;
-		this.key = key;
-		this.path = path;
-		this.explanation = explanation;
+		if (value) { this.value = value; }
+		if (stack) { this.stack = stack; }
+		if (key) { this.key = key; }
+		if (path) { this.path = path; }
+		if (explanation) { this.explanation = explanation; }
 	}
 }

--- a/src/Index.js
+++ b/src/Index.js
@@ -216,10 +216,10 @@ class Index {
 					assert.ok(!binding.routing_key, `Routing key is ignored for header exchanges, but set("${binding.routing_key}") for binding from ${binding.source} to ${binding.destination_type} "${binding.destination}" in vhost "${vhost}"`);
 				} else if (from.type === 'topic') {
 					// TODO: TEST THIS
-					assert.equal(binding.arguments['x-match'], undefined, `Match arguments are ignored for topic exchanges, but set for binding from ${binding.source} to ${binding.destination_type} "${binding.destination}" in vhost "${vhost}"`);
+					assert.equal(binding.arguments?.['x-match'], undefined, `Match arguments are ignored for topic exchanges, but set for binding from ${binding.source} to ${binding.destination_type} "${binding.destination}" in vhost "${vhost}"`);
 				} else if (from.type === 'direct') {
 					// TODO: TEST THIS
-					assert.equal(binding.arguments['x-match'], undefined, `Match arguments are ignored for direct exchanges, but set for binding from ${binding.source} to ${binding.destination_type} "${binding.destination}" in vhost "${vhost}"`);
+					assert.equal(binding.arguments?.['x-match'], undefined, `Match arguments are ignored for direct exchanges, but set for binding from ${binding.source} to ${binding.destination_type} "${binding.destination}" in vhost "${vhost}"`);
 				} else {
 					assert.fail(`Unexpected binding type: ${from.type}`);
 				}

--- a/src/Index.js
+++ b/src/Index.js
@@ -17,7 +17,18 @@ const pushToMapOfArrays = (map, key, item) => {
 // A quick index to be able to quickly see which resources we've seen without the need to iterate through all
 // of them every time.
 class Index {
+	static fromDefinitions(definitions, throwOnFirstError) {
+		const index = new Index();
+		index.build(definitions, throwOnFirstError);
+
+		return index;
+	}
+
 	constructor() {
+		this.init();
+	}
+
+	init() {
 		const db = {
 			// queues: vhost.name -> Q
 			queue: new Map(),
@@ -88,6 +99,7 @@ class Index {
 
 	build(definitions, throwOnFirstError = true) {
 		nodeAssert.ok(definitions && typeof definitions, 'object');
+		this.init();
 
 		const assert = failureCollector(throwOnFirstError);
 

--- a/src/Index.js
+++ b/src/Index.js
@@ -165,7 +165,7 @@ class Index {
 
 		for (const vhost of definitions.vhosts) {
 			if (!vhost.name) {
-				// will not report failure because it's probably already caught
+				// will not report failure because it'd already be caught by the structural validation
 				continue;
 			}
 			assert.ok(!this.vhost.get(vhost.name), `Duplicate vhost: "${vhost.name}"`);
@@ -174,24 +174,27 @@ class Index {
 
 		for (const queue of definitions.queues) {
 			if (!queue.name || !queue.vhost) {
-				// will not report failure because it's probably already caught
+				// will not report failure because it'd already be caught by the structural validation
 				continue;
 			}
+			assert.ok(this.vhost.get(queue.vhost), `Missing vhost: "${queue.vhost}"`);
 			assert.ok(!this.queue.get(queue.name, queue.vhost), `Duplicate queue: "${queue.name}" in vhost "${queue.vhost}"`);
 			this.queue.set(queue.name, queue.vhost, queue);
 		}
 
 		for (const exchange of definitions.exchanges) {
 			if (!exchange.name || !exchange.vhost) {
-				// will not report failure because it's probably already caught
+				// will not report failure because it'd already be caught by the structural validation
 				continue;
 			}
+			assert.ok(this.vhost.get(exchange.vhost), `Missing vhost: "${exchange.vhost}"`);
 			assert.ok(!this.exchange.get(exchange.name, exchange.vhost), `Duplicate exchange: "${exchange.name}" in vhost "${exchange.vhost}"`);
 			this.exchange.set(exchange.name, exchange.vhost, exchange);
 		}
 
 		for (const binding of definitions.bindings) {
 			const { vhost } = binding;
+			assert.ok(this.vhost.get(vhost), `Missing vhost: "${vhost}"`);
 			const from = this.exchange.get(binding.source, vhost);
 			assert.ok(from, `Missing source exchange for binding: "${binding.source}" in vhost "${vhost}"`);
 

--- a/src/Index.js
+++ b/src/Index.js
@@ -14,9 +14,41 @@ const pushToMapOfArrays = (map, key, item) => {
 	}
 };
 
+const key = {
+	resource: (resource) => {
+		if (typeof resource.destination_type === 'string') {
+			return key.binding(resource);
+		}
+		if (typeof resource.type === 'string') {
+			return key.exchange(resource);
+		}
+		if (typeof resource.vhost === 'string') {
+			return key.queue(resource);
+		}
+		if (typeof resource.name === 'string') {
+			return key.vhost(resource);
+		}
+		const err = new Error('Invalid resource');
+		err.context = resource;
+		throw err;
+	},
+	vhost: ({ name }) => `${name}`,
+	queue: ({ name, vhost }) => `Q[${name} @ ${vhost}]`,
+	exchange: ({ name, vhost }) => `E[${name} @ ${vhost}]`,
+	binding: ({ vhost, source, destination_type, destination, routing_key, arguments: args }) => `B[${source}->${destination_type}.${destination} @ ${vhost}](${routing_key}/${key.args(args)})`,
+	args: (args) => {
+		return Object.entries(args).sort(([a], [b]) => a < b ? -1 : 1).map((p) => p.join('=')).join();
+	},
+};
+
 // A quick index to be able to quickly see which resources we've seen without the need to iterate through all
 // of them every time.
 class Index {
+	vhost = null;
+	queue = null;
+	exchange = null;
+	binding = null;
+
 	static fromDefinitions(definitions, throwOnFirstError) {
 		const index = new Index();
 		index.build(definitions, throwOnFirstError);
@@ -40,61 +72,89 @@ class Index {
 			resourceByVhost: new Map(),
 			// bindings: source -> destination -> args
 			binding: new Map(),
-			// bindings: destination -> [source]
+			// bindings: {resource} -> binding[]
 			bindingByDestination: new Map(),
+			// bindings: {resource} -> binding[]
+			bindingBySource: new Map(),
 		};
 
 		const maps = {
 			vhost: {
+				count() { return db.vhost.size; },
+				all() { return [...db.vhost.values()]; },
 				get(name) { return db.vhost.get(name); },
-				has(name) { return db.vhost.has(name); },
 				delete(name) { return db.vhost.delete(name); },
 				set(name, item) { return db.vhost.set(name, item); },
 			},
 			queue: {
-				get(name, vhost) { assertStr(name, 'name'); assertStr(vhost, 'vhost'); return db.queue.get([name, vhost].join(' @ ')); },
-				has(name, vhost) { assertStr(name, 'name'); assertStr(vhost, 'vhost'); return db.queue.has([name, vhost].join(' @ ')); },
-				delete(name, vhost) { assertStr(name, 'name'); assertStr(vhost, 'vhost'); return db.queue.delete([name, vhost].join(' @ ')); },
+				count() { return db.queue.size; },
+				all() { return [...db.queue.values()]; },
+				get(name, vhost) {
+					assertStr(name, 'name');
+					assertStr(vhost, 'vhost');
+					return db.queue.get(key.queue({ name, vhost }));
+				},
+				delete(name, vhost) {
+					assertStr(name, 'name');
+					assertStr(vhost, 'vhost');
+					return db.queue.delete(key.queue({ name, vhost }));
+				},
 				set(name, vhost, item) {
 					pushToMapOfArrays(db.resourceByVhost, vhost, item);
-					return db.queue.set([name, vhost].join(' @ '), item);
+					return db.queue.set(key.queue({ name, vhost }), item);
 				},
 			},
 			exchange: {
-				get(name, vhost) { assertStr(name, 'name'); assertStr(vhost, 'vhost'); return db.exchange.get([name, vhost].join(' @ ')); },
-				has(name, vhost) { assertStr(name, 'name'); assertStr(vhost, 'vhost'); return db.exchange.has([name, vhost].join(' @ ')); },
-				delete(name, vhost) { assertStr(name, 'name'); assertStr(vhost, 'vhost'); return db.exchange.delete([name, vhost].join(' @ ')); },
+				count() { return db.exchange.size; },
+				all() { return [...db.exchange.values()]; },
+				get(name, vhost) {
+					assertStr(name, 'name');
+					assertStr(vhost, 'vhost');
+					return db.exchange.get(key.exchange({ name, vhost }));
+				},
+				delete(name, vhost) {
+					assertStr(name, 'name');
+					assertStr(vhost, 'vhost');
+					return db.exchange.delete(key.exchange({ name, vhost }));
+				},
 				set(name, vhost, item) {
 					pushToMapOfArrays(db.resourceByVhost, vhost, item);
-					return db.exchange.set([name, vhost].join(' @ '), item);
+					return db.exchange.set(key.exchange({ name, vhost }), item);
 				},
 			},
 			binding: {
-				get(from, to, args) { assertObj(from); assertObj(to); return db.binding.get(from)?.get(to)?.get(args) ?? false; },
-				has(from, to, args) { assertObj(from); assertObj(to); return db.binding.get(from)?.get(to)?.get(args) ?? false; },
-				delete(from, to, args) { assertObj(from); assertObj(to); return db.binding.get(from)?.get(to)?.delete(args); },
-				set(from, to, args, item) {
-					assertObj(from);
-					assertObj(to);
-					assertObj(item);
-					let fromMap = db.binding.get(from);
-					if (!fromMap) {
-						fromMap = new Map();
-						db.binding.set(from, fromMap);
-					}
-					let toMap = fromMap.get(to);
-					if (!toMap) {
-						toMap = new Map();
-						fromMap.set(to, toMap);
-					}
-					pushToMapOfArrays(db.bindingByDestination, to, item);
-					return toMap.set(args, item);
+				count() { return db.binding.size; },
+				get(binding) {
+					return db.binding.get(key.binding(binding));
 				},
+				delete(binding) { return db.binding.delete(key.binding(binding)); },
+				set(binding) {
+					assertObj(binding);
+					const source = maps.exchange.get(binding.source, binding.vhost);
+					if (source) {
+						pushToMapOfArrays(db.bindingBySource, key.resource(source), binding);
+					}
+					const destination = maps[binding.destination_type].get(binding.destination, binding.vhost);
+					if (destination) {
+						pushToMapOfArrays(db.bindingByDestination, key.resource(destination), binding);
+					}
+					return db.binding.set(key.binding(binding), binding);
+				},
+				byDestination(resource) {
+					return db.bindingByDestination.get(key.resource(resource));
+				},
+				bySource(resource) {
+					return db.bindingBySource.get(key.resource(resource));
+				},
+			},
+			resource: {
+				get byVhost() { return db.resourceByVhost; },
 			},
 		};
 
-		this.maps = maps;
-		this.db = db;
+		for (const [ns, api] of Object.entries(maps)) {
+			this[ns] = api;
+		}
 	}
 
 	build(definitions, throwOnFirstError = true) {
@@ -108,8 +168,8 @@ class Index {
 				// will not report failure because it's probably already caught
 				continue;
 			}
-			assert.ok(!this.maps.vhost.get(vhost.name), `Duplicate vhost: "${vhost.name}"`);
-			this.maps.vhost.set(vhost.name, vhost);
+			assert.ok(!this.vhost.get(vhost.name), `Duplicate vhost: "${vhost.name}"`);
+			this.vhost.set(vhost.name, vhost);
 		}
 
 		for (const queue of definitions.queues) {
@@ -117,8 +177,8 @@ class Index {
 				// will not report failure because it's probably already caught
 				continue;
 			}
-			assert.ok(!this.maps.queue.get(queue.name, queue.vhost), `Duplicate queue: "${queue.name}" in vhost "${queue.vhost}"`);
-			this.maps.queue.set(queue.name, queue.vhost, queue);
+			assert.ok(!this.queue.get(queue.name, queue.vhost), `Duplicate queue: "${queue.name}" in vhost "${queue.vhost}"`);
+			this.queue.set(queue.name, queue.vhost, queue);
 		}
 
 		for (const exchange of definitions.exchanges) {
@@ -126,41 +186,35 @@ class Index {
 				// will not report failure because it's probably already caught
 				continue;
 			}
-			assert.ok(!this.maps.exchange.get(exchange.name, exchange.vhost), `Duplicate exchange: "${exchange.name}" in vhost "${exchange.vhost}"`);
-			this.maps.exchange.set(exchange.name, exchange.vhost, exchange);
+			assert.ok(!this.exchange.get(exchange.name, exchange.vhost), `Duplicate exchange: "${exchange.name}" in vhost "${exchange.vhost}"`);
+			this.exchange.set(exchange.name, exchange.vhost, exchange);
 		}
 
 		for (const binding of definitions.bindings) {
 			const { vhost } = binding;
-			const from = this.maps.exchange.get(binding.source, vhost);
+			const from = this.exchange.get(binding.source, vhost);
 			assert.ok(from, `Missing source exchange for binding: "${binding.source}" in vhost "${vhost}"`);
 
-			const to = this.maps[binding.destination_type].get(binding.destination, vhost);
+			const to = this[binding.destination_type].get(binding.destination, vhost);
 			assert.ok(to, `Missing destination ${binding.destination_type} for binding: "${binding.destination}" in vhost "${vhost}"`);
 
 			if (from) {
-				let args = undefined;
 				if (from.type === 'headers') {
 					// TODO: TEST THIS
 					assert.ok(!binding.routing_key, `Routing key is ignored for header exchanges, but set("${binding.routing_key}") for binding from ${binding.source} to ${binding.destination_type} "${binding.destination}" in vhost "${vhost}"`);
-					args = binding.arguments;
 				} else if (from.type === 'topic') {
 					// TODO: TEST THIS
 					assert.equal(binding.arguments['x-match'], undefined, `Match arguments are ignored for topic exchanges, but set for binding from ${binding.source} to ${binding.destination_type} "${binding.destination}" in vhost "${vhost}"`);
-					args = binding.routing_key;
 				} else if (from.type === 'direct') {
 					// TODO: TEST THIS
 					assert.equal(binding.arguments['x-match'], undefined, `Match arguments are ignored for direct exchanges, but set for binding from ${binding.source} to ${binding.destination_type} "${binding.destination}" in vhost "${vhost}"`);
-					args = binding.routing_key;
 				} else {
 					assert.fail(`Unexpected binding type: ${from.type}`);
 				}
-
-				if (to) {
-					assert.ok(!this.maps.binding.get(from, to, args), `Duplicate binding from "${binding.source}" to ${binding.destination_type} "${binding.destination}" in vhost "${binding.vhost}"`);
-					this.maps.binding.set(from, to, args, binding);
-				}
 			}
+
+			assert.ok(!this.binding.get(binding), `Duplicate binding from "${binding.source}" to ${binding.destination_type} "${binding.destination}" in vhost "${binding.vhost}"`);
+			this.binding.set(binding);
 		}
 
 		return assert.collectFailures();

--- a/src/diff.js
+++ b/src/diff.js
@@ -1,9 +1,7 @@
-import { inspect, isDeepStrictEqual } from 'util';
+import { isDeepStrictEqual } from 'util';
 
 import { assertRootStructure } from './structure.js';
 import Index, { key } from './Index.js';
-
-inspect.defaultOptions.depth++;
 
 const diffMapsConsuming = (before, after) => {
 	const added = [];
@@ -36,8 +34,8 @@ const diff = (beforeDef, afterDef) => {
 	assertRootStructure(beforeDef);
 	assertRootStructure(afterDef);
 
-	const before = Index.fromDefinitions(beforeDef);
-	const after = Index.fromDefinitions(afterDef);
+	const before = Index.fromDefinitions(beforeDef, false);
+	const after = Index.fromDefinitions(afterDef, false);
 
 	const added = { vhosts: [], queues: [], exchanges: [], bindings: [] };
 	const deleted = { vhosts: [], queues: [], exchanges: [], bindings: [] };

--- a/src/diff.js
+++ b/src/diff.js
@@ -1,0 +1,65 @@
+import { inspect, isDeepStrictEqual } from 'util';
+
+import { assertRootStructure } from './structure.js';
+import Index, { key } from './Index.js';
+
+inspect.defaultOptions.depth++;
+
+const diffMapsConsuming = (before, after) => {
+	const added = [];
+	const deleted = [];
+	const changed = [];
+
+	for (const afterItem of after.all()) {
+		const beforeItem = before.getByKey(key.resource(afterItem));
+		after.remove(afterItem);
+		before.remove(afterItem);
+		if (beforeItem === undefined) {
+			added.push(afterItem);
+		} else if (!isDeepStrictEqual(beforeItem, afterItem)) {
+			changed.push({ before: beforeItem, after: afterItem });
+		}
+	}
+	for (const beforeItem of before.all()) {
+		before.remove(beforeItem);
+		deleted.push(beforeItem);
+	}
+
+	return {
+		added,
+		deleted,
+		changed,
+	};
+};
+
+const diff = (beforeDef, afterDef) => {
+	assertRootStructure(beforeDef);
+	assertRootStructure(afterDef);
+
+	const before = Index.fromDefinitions(beforeDef);
+	const after = Index.fromDefinitions(afterDef);
+
+	const added = { vhosts: [], queues: [], exchanges: [], bindings: [] };
+	const deleted = { vhosts: [], queues: [], exchanges: [], bindings: [] };
+	const changed = { vhosts: [], queues: [], exchanges: [], bindings: [] };
+
+	const collectDiff = (key, beforeMap, afterMap) => {
+		const changes = diffMapsConsuming(beforeMap, afterMap);
+		added[key].push(...changes.added);
+		deleted[key].push(...changes.deleted);
+		changed[key].push(...changes.changed);
+	};
+
+	collectDiff('vhosts', before.vhost, after.vhost);
+	collectDiff('queues', before.queue, after.queue);
+	collectDiff('exchanges', before.exchange, after.exchange);
+	collectDiff('bindings', before.binding, after.binding);
+
+	return {
+		added,
+		deleted,
+		changed,
+	};
+};
+
+export default diff;

--- a/src/failureCollector.js
+++ b/src/failureCollector.js
@@ -17,7 +17,7 @@ export default (throwOnFirstError = true) => {
 				return nodeAssert[method](...args);
 			} catch (err) {
 				// deduplicating all the "duplicate X" failures
-				const failure = new Failure({ message: err.message });
+				const failure = new Failure({ message: err.message, stack: err.stack });
 				failures.set(failure.message, failure);
 			}
 		};

--- a/src/relations.js
+++ b/src/relations.js
@@ -47,7 +47,6 @@ const assertRelations = (definitions, throwOnFirstError = true) => {
 	for (const [vhost, res] of index.resource.byVhost.entries()) {
 		assert.ok(index.vhost.get(vhost), `Missing vhost "${vhost}" used by ${formatResource(res[0])}${res.length > 1 ? ` and ${res.length - 1} other(s)` : ''}`);
 	}
-	// TODO: fail if anything references a missing vhost
 
 	return failures;
 };

--- a/src/relations.js
+++ b/src/relations.js
@@ -19,7 +19,7 @@ const assertRelations = (definitions, throwOnFirstError = true) => {
 
 	// test whether vhost is used anywhere
 	for (const vhost of definitions.vhosts) {
-		if (!index.db.resourceByVhost.get(vhost.name)) {
+		if (!index.resource.byVhost.get(vhost.name)) {
 			if (vhost.name) {
 				console.warn(`Warning: Unused vhost "${vhost.name}"`);
 			}
@@ -28,7 +28,7 @@ const assertRelations = (definitions, throwOnFirstError = true) => {
 
 	// test whether queue is used anywhere: ? -> Q
 	for (const queue of definitions.queues) {
-		if (!index.db.bindingByDestination.get(queue)) {
+		if (!index.binding.byDestination(queue)) {
 			if (queue.name && queue.vhost) {
 				console.warn(`Warning: Unbound queue "${queue.name}" in vhost "${queue.vhost}"`);
 			}
@@ -37,15 +37,15 @@ const assertRelations = (definitions, throwOnFirstError = true) => {
 
 	// test whether exchange is used anywhere: EX -> ? or ? -> EX
 	for (const exchange of definitions.exchanges) {
-		if (!index.db.binding.get(exchange) && !index.db.bindingByDestination.get(exchange)) {
+		if (!index.binding.bySource(exchange) && !index.binding.byDestination(exchange)) {
 			if (exchange.name && exchange.vhost) {
 				console.warn(`Warning: Unbound exchange "${exchange.name}" in vhost "${exchange.vhost}"`);
 			}
 		}
 	}
 
-	for (const [vhost, res] of index.db.resourceByVhost.entries()) {
-		assert.ok(index.maps.vhost.get(vhost), `Missing vhost "${vhost}" used by ${formatResource(res[0])}`);
+	for (const [vhost, res] of index.resource.byVhost.entries()) {
+		assert.ok(index.vhost.get(vhost), `Missing vhost "${vhost}" used by ${formatResource(res[0])}${res.length > 1 ? ` and ${res.length - 1} other(s)` : ''}`);
 	}
 	// TODO: fail if anything references a missing vhost
 

--- a/src/structure.js
+++ b/src/structure.js
@@ -111,7 +111,7 @@ const rootStructure = {
 		source: string(),
 		vhost: string(),
 		destination: string(),
-		destination_type: string(),
+		destination_type: enums(['exchange', 'queue']),
 		routing_key: nullable(string()),
 		arguments: optional(object()),
 	})),

--- a/src/usage.js
+++ b/src/usage.js
@@ -22,14 +22,14 @@ const assertUsage = (definitions, usageStats, throwOnFirstError = false) => {
 	for (const u of usageStats) {
 		const vhost = u.vhost;
 		if (u.exchange) {
-			if (!index.maps.exchange.has(u.exchange, vhost)) {
+			if (!index.exchange.get(u.exchange, vhost)) {
 				console.warn(`Warning: Used but missing exchange "${u.exchange}"" in "${vhost}"`);
 			}
-			if (!index.maps.queue.has(u.queue, vhost)) {
+			if (!index.queue.get(u.queue, vhost)) {
 				console.warn(`Warning: Used but missing queue "${u.queue}"" in "${vhost}"`);
 			}
 		} else if (u.queue) {
-			if (!index.maps.queue.has(u.queue, vhost)) {
+			if (!index.queue.get(u.queue, vhost)) {
 				console.warn(`Warning: Used but missing queue "${u.queue}"" in "${vhost}"`);
 			}
 		} else {
@@ -37,24 +37,24 @@ const assertUsage = (definitions, usageStats, throwOnFirstError = false) => {
 		}
 	}
 
-	const exchangeSizeBefore = index.db.exchange.size;
-	const queueSizeBefore = index.db.queue.size;
-	const vhostSizeBefore = index.db.vhost.size;
+	const exchangeSizeBefore = index.exchange.count();
+	const queueSizeBefore = index.queue.count();
+	const vhostSizeBefore = index.vhost.count();
 
 	for (const u of usageStats) {
 		const vhost = u.vhost;
-		index.maps.vhost.delete(vhost);
+		index.vhost.delete(vhost);
 		if (u.exchange) {
-			index.maps.exchange.delete(u.exchange, vhost);
-			index.maps.queue.delete(u.queue, vhost);
+			index.exchange.delete(u.exchange, vhost);
+			index.queue.delete(u.queue, vhost);
 		} else if (u.queue) {
-			index.maps.queue.delete(u.queue, vhost);
+			index.queue.delete(u.queue, vhost);
 		} else {
 			throw new Error('Unexpected usage record type');
 		}
 	}
 
-	const vhostUnused = [...index.db.vhost.values()];
+	const vhostUnused = index.vhost.all();
 	if (vhostSizeBefore > 1 && vhostUnused.length) {
 		for (const i of vhostUnused) {
 			console.warn(`Warning: Empirically unused vhost "${i.name}"`);
@@ -63,7 +63,7 @@ const assertUsage = (definitions, usageStats, throwOnFirstError = false) => {
 		assert.ok(vhostRatio < 0.3, `High ratio of unused vhosts: ${formatPercentage(vhostRatio)}`);
 	}
 
-	const exchangeUnused = [...index.db.exchange.values()];
+	const exchangeUnused = index.exchange.all();
 	if (exchangeSizeBefore && exchangeUnused.length) {
 		for (const i of exchangeUnused) {
 			console.warn(`Warning: Empirically unused exchange "${i.name}" in "${i.vhost}"`);
@@ -72,7 +72,7 @@ const assertUsage = (definitions, usageStats, throwOnFirstError = false) => {
 		assert.ok(exchangeRatio < 0.3, `High ratio of unused exchanges: ${formatPercentage(exchangeRatio)}`);
 	}
 
-	const queueUnused = [...index.db.queue.values()];
+	const queueUnused = index.queue.all();
 	if (queueSizeBefore && queueUnused.length) {
 		for (const i of queueUnused) {
 			console.warn(`Warning: Empirically unused queue "${i.name}" in "${i.vhost}"`);

--- a/src/usage.js
+++ b/src/usage.js
@@ -13,9 +13,8 @@ const assertUsage = (definitions, usageStats, throwOnFirstError = false) => {
 	nodeAssert.ok(Array.isArray(usageStats), `Expected array as usage stats. Got: ${inspect(usageStats)}`);
 
 	const assert = failureCollector(throwOnFirstError);
-	const index = new Index();
 	// collect failures but ignore issues for compiling usage failures
-	index.build(definitions, false);
+	const index = Index.fromDefinitions(definitions, false);
 
 	// Check resources that are used, but missing from definitions
 	// Likely to be temporary resources.

--- a/test/diff.js
+++ b/test/diff.js
@@ -1,0 +1,172 @@
+import { strict as assert } from 'assert';
+import { describe, it } from 'node:test';
+
+import { readJSONSync } from '../src/utils.js';
+import diff from '../src/diff.js';
+
+const copy = (obj) => {
+	return JSON.parse(JSON.stringify(obj));
+};
+
+const valid = readJSONSync('./fixtures/full.json');
+
+describe('diff', () => {
+	it('fn exists and takes 2 args', () => {
+		assert.equal(typeof diff, 'function');
+		assert.equal(diff.length, 2);
+	});
+
+	it('validates input objects to be definition files', () => {
+		diff(valid, valid);
+		assert.throws(() => {
+			const unvalid = copy(valid);
+			unvalid.exchanges = false;
+			diff(valid, unvalid);
+		});
+		assert.throws(() => {
+			const unvalid = copy(valid);
+			unvalid.exchanges = false;
+			diff(unvalid, valid);
+		});
+	});
+
+	it('catches changes to vhosts', () => {
+		const before = copy(valid);
+		const after = copy(valid);
+		before.vhosts.push({
+			name: 'deleted',
+		});
+		after.vhosts.push({
+			name: 'new',
+		});
+		const { added: { vhosts: added }, deleted: { vhosts: deleted } } = diff(before, after);
+		assert.equal(added.length, 1);
+		assert.equal(added[0].name, 'new');
+		assert.equal(deleted.length, 1);
+		assert.equal(deleted[0].name, 'deleted');
+	});
+
+	it('catches changes to queues', () => {
+		const before = copy(valid);
+		const after = copy(valid);
+		after.queues.push({
+			name: 'new',
+			vhost: '/',
+			durable: true,
+			auto_delete: false,
+		});
+		before.queues.push({
+			name: 'deleted',
+			vhost: '/',
+			durable: true,
+			auto_delete: false,
+		});
+		const changedItem = after.queues[0];
+		changedItem.durable = !changedItem.durable;
+		const { added: { queues: added }, deleted: { queues: deleted }, changed: { queues: changed } } = diff(before, after);
+		assert.equal(added.length, 1);
+		assert.equal(added[0].name, 'new');
+		assert.equal(deleted.length, 1);
+		assert.equal(deleted[0].name, 'deleted');
+		assert.equal(changed.length, 1);
+		assert.equal(changed[0].before.name, changedItem.name);
+		assert.equal(changed[0].before.durable, !changedItem.durable);
+		assert.equal(changed[0].after.name, changedItem.name);
+		assert.equal(changed[0].after.durable, changedItem.durable);
+	});
+
+	it('catches changes to exchanges', () => {
+		const before = copy(valid);
+		const after = copy(valid);
+		after.exchanges.push({
+			name: 'new',
+			vhost: '/',
+			type: 'topic',
+			durable: true,
+			auto_delete: false,
+		});
+		before.exchanges.push({
+			name: 'deleted',
+			vhost: '/',
+			type: 'headers',
+			durable: true,
+			auto_delete: false,
+		});
+		const changedItem = after.exchanges[0];
+		changedItem.durable = !changedItem.durable;
+		const { added: { exchanges: added }, deleted: { exchanges: deleted }, changed: { exchanges: changed } } = diff(before, after);
+		assert.equal(added.length, 1);
+		assert.equal(added[0].name, 'new');
+		assert.equal(deleted.length, 1);
+		assert.equal(deleted[0].name, 'deleted');
+		assert.equal(changed.length, 1);
+		assert.equal(changed[0].before.name, changedItem.name);
+		assert.equal(changed[0].before.durable, !changedItem.durable);
+		assert.equal(changed[0].after.name, changedItem.name);
+		assert.equal(changed[0].after.durable, changedItem.durable);
+	});
+
+	it('catches changes to bindings via routing key', () => {
+		const before = copy(valid);
+		const after = copy(valid);
+		// pick first two resource to create bindings between
+		const exchange = before.exchanges.find((e) => e.type === 'topic');
+		const queue = before.queues.find((q) => q.vhost === exchange.vhost);
+		after.bindings.push({
+			vhost: exchange.vhost,
+			source: exchange.name,
+			destination: queue.name,
+			destination_type: 'queue',
+			routing_key: 'a.b',
+		});
+		before.bindings.push({
+			vhost: exchange.vhost,
+			source: exchange.name,
+			destination: queue.name,
+			destination_type: 'queue',
+			routing_key: 'd.e',
+		});
+		const { added: { bindings: added }, deleted: { bindings: deleted }, changed: { bindings: changed } } = diff(before, after);
+		assert.equal(added.length, 1);
+		assert.equal(added[0].routing_key, 'a.b');
+		assert.equal(deleted.length, 1);
+		assert.equal(deleted[0].routing_key, 'd.e');
+		assert.equal(changed.length, 0);
+	});
+
+	it('catches changes to bindings via args', () => {
+		const before = copy(valid);
+		const after = copy(valid);
+		// pick first two resource to create bindings between
+		const exchange = before.exchanges.find((e) => e.type === 'headers');
+		const queue = before.queues.find((q) => q.vhost === exchange.vhost);
+		after.bindings.push({
+			vhost: exchange.vhost,
+			source: exchange.name,
+			destination: queue.name,
+			destination_type: 'queue',
+			routing_key: '',
+			arguments: {
+				'x-match': 'any',
+				h1: 'v2',
+			},
+		});
+		before.bindings.push({
+			vhost: exchange.vhost,
+			source: exchange.name,
+			destination: queue.name,
+			destination_type: 'queue',
+			routing_key: '',
+			arguments: {
+				'x-match': 'any',
+				h1: 'v1',
+			},
+		});
+		const { added: { bindings: added }, deleted: { bindings: deleted }, changed: { bindings: changed } } = diff(before, after);
+		assert.equal(added.length, 1);
+		assert.equal(added[0].arguments.h1, 'v2');
+		assert.equal(deleted.length, 1);
+		assert.equal(deleted[0].arguments.h1, 'v1');
+		assert.equal(changed.length, 0);
+	});
+});


### PR DESCRIPTION
- feat: create fromDefinitions shortcut on Index
- feat: restrict destination_type to enum
- refactor: clean up index api
- feat: fail on missing vhosts
- feat: implement diffing
- feat: don't crash if `arguments` is unset on binding
- feat: use fromDefinitions
- feat: add diff subcommand to the cli
