### PR TITLE
feat: collect all failures even if one throws

### DIFF
--- a/src/Index.js
+++ b/src/Index.js
@@ -43,7 +43,7 @@ export const detectResourceType = (resource) => {
 	if (typeof resource.write === 'string') {
 		return 'topic_permissions';
 	}
-	const err = new Error('Unknown resource');
+	const err = new Error(`Unknown resource: ${JSON.stringify(resource)}`);
 	err.context = resource;
 	throw err;
 };
@@ -183,33 +183,26 @@ class Index {
 		const assert = failureCollector(throwOnFirstError);
 
 		for (const vhost of definitions.vhosts) {
-			if (!vhost.name) {
-				// will not report failure because it'd already be caught by the structural validation
-				continue;
-			}
+			// will not report failure because it'd already be caught by the structural validation
+			try { this.vhosts.hash(vhost); } catch { continue; }
 			assert.ok(!this.vhosts.get(vhost), `Duplicate vhost: "${vhost.name}"`);
 			this.vhosts.add(vhost);
 		}
 
 		for (const queue of definitions.queues) {
-			if (!queue.name || !queue.vhost) {
-				// will not report failure because it'd already be caught by the structural validation
-				continue;
-			}
+			try { this.queues.hash(queue); } catch { continue; }
 			assert.ok(!this.queues.get(queue), `Duplicate queue: "${queue.name}" in vhost "${queue.vhost}"`);
 			this.queues.add(queue);
 		}
 
 		for (const exchange of definitions.exchanges) {
-			if (!exchange.name || !exchange.vhost) {
-				// will not report failure because it'd already be caught by the structural validation
-				continue;
-			}
+			try { this.exchanges.hash(exchange); } catch { continue; }
 			assert.ok(!this.exchanges.get(exchange), `Duplicate exchange: "${exchange.name}" in vhost "${exchange.vhost}"`);
 			this.exchanges.add(exchange);
 		}
 
 		for (const binding of definitions.bindings) {
+			try { this.bindings.hash(binding); } catch { continue; }
 			const { vhost } = binding;
 			const from = this.exchanges.get({ vhost, name: binding.source });
 			assert.ok(from, `Missing source exchange for binding: "${binding.source}" in vhost "${vhost}"`);
@@ -237,31 +230,22 @@ class Index {
 		}
 
 		for (const user of definitions.users) {
+			try { this.users.hash(user); } catch { continue; }
 			const { name } = user;
-			if (!name) {
-				// will not report failure because it'd already be caught by the structural validation
-				continue;
-			}
 			assert.ok(!this.users.get(user), `Duplicate user: "${name}"`);
 			this.users.add(user);
 		}
 
 		for (const permission of definitions.permissions) {
+			try { this.permissions.hash(permission); } catch { continue; }
 			const { user, vhost } = permission;
-			if (!user || !vhost) {
-				// will not report failure because it'd already be caught by the structural validation
-				continue;
-			}
 			assert.ok(!this.permissions.get(permission), `Duplicate permission for user "${user}" in vhost "${vhost}"`);
 			this.permissions.add(permission);
 		}
 
 		for (const permission of definitions.topic_permissions) {
+			try { this.topic_permissions.hash(permission); } catch { continue; }
 			const { user, vhost } = permission;
-			if (!user || !vhost) {
-				// will not report failure because it'd already be caught by the structural validation
-				continue;
-			}
 			assert.ok(!this.topic_permissions.get(permission), `Duplicate topic permission for user "${user}" in vhost "${vhost}.\n${JSON.stringify(permission)}\n${JSON.stringify(this.topic_permissions.get(permission))}"`);
 			this.topic_permissions.add(permission);
 		}

--- a/src/info.js
+++ b/src/info.js
@@ -1,11 +1,11 @@
 const printInfo = (definitions) => {
 	console.log('Total nr of:');
-	console.log('- vhosts:', definitions.vhosts.length);
-	console.log('- exchanges:', definitions.exchanges.length);
-	console.log('- queues:', definitions.queues.length);
-	console.log('- users:', definitions.users.length);
-	console.log('- permissions:', definitions.permissions.length);
-	console.log('- topic permissions:', definitions.topic_permissions.length);
+	console.log('- vhosts:', definitions.vhosts?.length ?? 0);
+	console.log('- exchanges:', definitions.exchanges?.length ?? 0);
+	console.log('- queues:', definitions.queues?.length ?? 0);
+	console.log('- users:', definitions.users?.length ?? 0);
+	console.log('- permissions:', definitions.permissions?.length ?? 0);
+	console.log('- topic permissions:', definitions.topic_permissions?.length ?? 0);
 };
 
 export default printInfo;

--- a/src/validate.js
+++ b/src/validate.js
@@ -7,15 +7,21 @@ import Failure from './Failure.js';
 
 export * from './structure.js';
 
+const tryCollect = (fn) => {
+	try {
+		return fn() || [];
+	} catch (err) {
+		return [err];
+	}
+};
+
 export const validateAll = (definitions, usageStats) => {
 	printInfo(definitions);
 
 	return [
-		...Failure.arrayFromSuperstructError(
-			validateRootStructure(definitions)
-		),
-		...validateRelations(definitions),
-		...(usageStats && validateUsage(definitions, usageStats) || []),
+		...(tryCollect(() => Failure.arrayFromSuperstructError(validateRootStructure(definitions)))),
+		...(tryCollect(() => validateRelations(definitions))),
+		...(tryCollect(() => usageStats && validateUsage(definitions, usageStats))),
 	];
 };
 

--- a/src/validate.js
+++ b/src/validate.js
@@ -7,17 +7,7 @@ import Failure from './Failure.js';
 
 export * from './structure.js';
 
-// validateUsage if usageStatsPath is set
-const condValidateUsage = (definitions, usageStatsPath) => {
-	if (usageStatsPath && typeof usageStatsPath === 'string') {
-		return validateUsage(definitions, readJSONSync(usageStatsPath));
-	}
-	return [];
-};
-
-const validateFromFile = (path, usageStatsPath) => {
-	const definitions = readJSONSync(path);
-
+export const validateAll = (definitions, usageStats) => {
 	printInfo(definitions);
 
 	return [
@@ -25,8 +15,15 @@ const validateFromFile = (path, usageStatsPath) => {
 			validateRootStructure(definitions)
 		),
 		...validateRelations(definitions),
-		...condValidateUsage(definitions, usageStatsPath),
+		...(usageStats && validateUsage(definitions, usageStats) || []),
 	];
 };
 
-export default validateFromFile;
+const validateAllFromFile = (path, usageStatsPath) => {
+	const definitions = readJSONSync(path);
+	const usageStats = usageStatsPath && typeof usageStatsPath === 'string' ? readJSONSync(usageStatsPath) : null;
+
+	return validateAll(definitions, usageStats);
+};
+
+export default validateAllFromFile;

--- a/test/structure.js
+++ b/test/structure.js
@@ -1,7 +1,8 @@
 import { strict as assert } from 'assert';
 import { describe, it } from 'node:test';
 
-import { assertRootStructure, assertPart, assertFromFile } from '../src/validate.js';
+import { readJSONSync } from '../src/utils.js';
+import { assertRootStructure, assertPart, assertFromFile, validateAll } from '../src/validate.js';
 
 describe('assertFromFile', () => {
 	it('empty', () => {
@@ -63,5 +64,15 @@ describe('invalid strings', () => {
 				name: 'user.​name',
 			}]);
 		}, /unexpected char/);
+	});
+});
+
+describe('validateAll', () => {
+	it('reports structural errors if hash functions throw', () => {
+		const valid = readJSONSync('./fixtures/full.json');
+		valid.topic_permissions.push(valid.permissions[0]);
+		const failures = validateAll(valid);
+		console.log(failures);
+		assert.equal(failures.length, 2);
 	});
 });


### PR DESCRIPTION
- refactor: separate validateAll's JS API
- fix: skip resource if hashing fails
- feat: collect all failures even if one of the validation fn throws
- fix: don't crash while printing info if some fields are missing
- feat: test collecting all failures
